### PR TITLE
【Fixed】最寄り駅登録・編集機能の実装、全体調整

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-
 gem 'rails', '~> 5.2.3'
 gem 'sqlite3'
 gem 'puma', '~> 3.0'

--- a/app/assets/stylesheets/property.scss
+++ b/app/assets/stylesheets/property.scss
@@ -2,6 +2,10 @@ a {
   color: black;
 }
 
+h2 {
+  font-size: 1.2rem;
+}
+
 ul {
   list-style: none;
 }

--- a/app/assets/stylesheets/property.scss
+++ b/app/assets/stylesheets/property.scss
@@ -39,6 +39,10 @@ table {
   line-height: 3rem;
   border-bottom: solid 1px gray;
 }
+.show_station {
+  padding: 20px;
+  line-height: 3rem;
+}
 
 .show_item {
   font-weight: bold;

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -13,10 +13,18 @@ class PropertiesController < ApplicationController
 
   def create
     @property = Property.new(get_params)
+    2.times do
+      @property.stations.build
+    end
     if params[:back]
       render :new
     else
       if @property.save
+        @property.stations.each do |station|
+          if station.line_near.blank? && station.station_near.blank? && station.minutes_needed.blank?
+            station.destroy
+          end
+        end
         redirect_to properties_path, notice: "物件を登録しました。"
       else
         render :new
@@ -33,6 +41,7 @@ class PropertiesController < ApplicationController
   end
 
   def update
+    @property.stations.build
     if @property.update(get_params)
       @property.stations.each do |station|
         if station.line_near.blank? && station.station_near.blank? && station.minutes_needed.blank?
@@ -52,8 +61,13 @@ class PropertiesController < ApplicationController
 
   def confirm
     @property = Property.new(get_params)
+    2.times do
+      @property.stations.build
+    end
     @stations = @property.stations.all
-    render :new if @property.invalid?
+    if @property.invalid?
+      render :new
+    end
   end
 
   private

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -44,6 +44,7 @@ class PropertiesController < ApplicationController
 
   def confirm
     @property = Property.new(get_params)
+    @stations = @property.stations
     render :new if @property.invalid?
   end
 

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -72,8 +72,7 @@ class PropertiesController < ApplicationController
                             station_near
                             minutes_needed
                             id
-                            _destroy]
-                         )
+                            _destroy])
   end
 
   def station_form_increase

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -66,7 +66,8 @@ class PropertiesController < ApplicationController
       stations_attributes: [:line_near,
                            :station_near,
                            :minutes_needed,
-                           :id]
+                           :id,
+                           :_destroy]
                          )
   end
 end

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -6,7 +6,9 @@ class PropertiesController < ApplicationController
 
   def new
     @property = Property.new
-    @property.stations.build
+    2.times do
+      @property.stations.build
+    end
   end
 
   def create
@@ -27,6 +29,7 @@ class PropertiesController < ApplicationController
   end
 
   def edit
+    @property.stations.build
   end
 
   def update
@@ -44,7 +47,8 @@ class PropertiesController < ApplicationController
 
   def confirm
     @property = Property.new(get_params)
-    @stations = @property.stations
+    @stations = []
+    2.times { @stations << @property.stations.build }
     render :new if @property.invalid?
   end
 

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -23,6 +23,7 @@ class PropertiesController < ApplicationController
   end
 
   def show
+    @stations = @property.stations.all
   end
 
   def edit

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -47,8 +47,7 @@ class PropertiesController < ApplicationController
 
   def confirm
     @property = Property.new(get_params)
-    @stations = []
-    2.times { @stations << @property.stations.build }
+    @stations = @property.stations.all
     render :new if @property.invalid?
   end
 

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -63,7 +63,7 @@ class PropertiesController < ApplicationController
       stations_attributes: [:line_near,
                            :station_near,
                            :minutes_needed,
-                           :property_id]
+                           :id]
                          )
   end
 end

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -34,6 +34,11 @@ class PropertiesController < ApplicationController
 
   def update
     if @property.update(get_params)
+      @property.stations.each do |station|
+        if station.line_near.blank? && station.station_near.blank? && station.minutes_needed.blank?
+          station.destroy
+        end
+      end
       redirect_to property_path(@property.id), notice: "物件を編集しました。"
     else
       render :edit

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -5,5 +5,9 @@ class Property < ApplicationRecord
   validates :old, presence:true, numericality:{ only_integer:true, greater_than_or_equal_to: 0 }, length:{ maximum: 3 }
   validates :comment, length:{ maximum: 255 }
   has_many :stations, dependent: :destroy
-  accepts_nested_attributes_for :stations, allow_destroy: true
+  accepts_nested_attributes_for :stations, reject_if: :all_blank, allow_destroy: true
+
+  def reject_empty_station
+    attributes.merge!(_destroy: 1) if judge = true
+  end
 end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -5,9 +5,12 @@ class Property < ApplicationRecord
   validates :old, presence:true, numericality:{ only_integer:true, greater_than_or_equal_to: 0 }, length:{ maximum: 3 }
   validates :comment, length:{ maximum: 255 }
   has_many :stations, dependent: :destroy
-  accepts_nested_attributes_for :stations, reject_if: :all_blank, allow_destroy: true
+  accepts_nested_attributes_for :stations,reject_if: :all_blank, allow_destroy: true
 
   def reject_empty_station
-    attributes.merge!(_destroy: 1) if judge = true
+    line_near = attributes[:line_near].nil?
+    station_near = attributes[:station_near].nil?
+    minutes_needed = attributes[:minutes_needed].nil?
+    attributes.merge!(_destroy:"1") if line_near && station_near && minutes_needed
   end
 end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -6,11 +6,4 @@ class Property < ApplicationRecord
   validates :comment, length:{ maximum: 255 }
   has_many :stations, dependent: :destroy
   accepts_nested_attributes_for :stations,reject_if: :all_blank, allow_destroy: true
-
-  def reject_empty_station
-    line_near = attributes[:line_near].nil?
-    station_near = attributes[:station_near].nil?
-    minutes_needed = attributes[:minutes_needed].nil?
-    attributes.merge!(_destroy:"1") if line_near && station_near && minutes_needed
-  end
 end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -5,5 +5,5 @@ class Property < ApplicationRecord
   validates :old, presence:true, numericality:{ only_integer:true, greater_than_or_equal_to: 0 }, length:{ maximum: 3 }
   validates :comment, length:{ maximum: 255 }
   has_many :stations, dependent: :destroy
-  accepts_nested_attributes_for :stations
+  accepts_nested_attributes_for :stations, allow_destroy: true
 end

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -2,5 +2,5 @@ class Station < ApplicationRecord
   belongs_to :property
   validates :line_near, length:{ maximum: 20 }
   validates :station_near, length: { maximum: 30 }
-  validates :minutes_needed, length:{ maximum: 4 }
+  validates :minutes_needed, length: { maximum: 4 }
 end

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -1,3 +1,6 @@
 class Station < ApplicationRecord
   belongs_to :property
+  validates :line_near, length:{ maximum: 20 }
+  validates :station_near, length: { maximum: 30 }
+  validates :minutes_needed, numericality:{ only_integer:true, greater_than_or_equal_to: 0 }, length:{ maximum: 4 }
 end

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -2,5 +2,5 @@ class Station < ApplicationRecord
   belongs_to :property
   validates :line_near, length:{ maximum: 20 }
   validates :station_near, length: { maximum: 30 }
-  validates :minutes_needed, numericality:{ only_integer:true, greater_than_or_equal_to: 0 }, length:{ maximum: 4 }
+  validates :minutes_needed, length:{ maximum: 4 }
 end

--- a/app/views/properties/_form.html.erb
+++ b/app/views/properties/_form.html.erb
@@ -19,7 +19,10 @@
     <p><%= form.text_area :comment %></p>
   </div>
   <div class="station_form">
+    <% n = 0 %>
     <%= form.fields_for :stations do |s| %>
+      <% n = n + 1 %>
+      <h2>最寄り駅<%= n  %></h2>
       <p><%= s.label :line_near, "路線名" %></p>
       <p><%= s.text_field :line_near %></p>
       <p><%= s.label :station_near, "駅名" %></p>

--- a/app/views/properties/_form.html.erb
+++ b/app/views/properties/_form.html.erb
@@ -38,7 +38,7 @@
   <% end %>
 <% end %>
 <% if form_for_new_property? %>
-  <p><%= link_to '戻る', 'javascript:history.back()' %></p>
+  <p><%= link_to '戻る', properties_path %></p>
 <% else %>
   <p>
     <%= link_to '詳細', property_path(@property.id) %> |

--- a/app/views/properties/confirm.html.erb
+++ b/app/views/properties/confirm.html.erb
@@ -15,13 +15,13 @@
         <li><span class="show_item">路線名</span> <%= station.line_near %></li>
         <li><span class="show_item">駅名</span> <%= station.station_near %></li>
         <li><span class="show_item">徒歩分数</span> <%= station.minutes_needed %>分</li>
-        <%= form.fields_for :station do |s| %>
+        <% end %>
+        <%= form.fields_for :stations do |s| %>
           <%= s.hidden_field :line_near %>
           <%= s.hidden_field :station_near %>
           <%= s.hidden_field :minutes_needed %>
           <%= s.hidden_field :property_id %>
         <% end %>
-          <% end %>
                 <ul>
   </div>
   <%= form.hidden_field :name %>

--- a/app/views/properties/confirm.html.erb
+++ b/app/views/properties/confirm.html.erb
@@ -9,20 +9,20 @@
     </ul>
   </div>
   <div class="show_station">
-          <ul class="show_list">
-    <% @property.stations.each_with_index do |station,index| %>
-      <h2>最寄り駅<%= index + 1 %></h2>
+    <ul class="show_list">
+      <% @property.stations.each_with_index do |station,index| %>
+        <h2>最寄り駅<%= index + 1 %></h2>
         <li><span class="show_item">路線名</span> <%= station.line_near %></li>
         <li><span class="show_item">駅名</span> <%= station.station_near %></li>
         <li><span class="show_item">徒歩分数</span> <%= station.minutes_needed %>分</li>
-        <% end %>
-        <%= form.fields_for :stations do |s| %>
-          <%= s.hidden_field :line_near %>
-          <%= s.hidden_field :station_near %>
-          <%= s.hidden_field :minutes_needed %>
-          <%= s.hidden_field :property_id %>
-        <% end %>
-                <ul>
+      <% end %>
+      <%= form.fields_for :stations do |s| %>
+        <%= s.hidden_field :line_near %>
+        <%= s.hidden_field :station_near %>
+        <%= s.hidden_field :minutes_needed %>
+        <%= s.hidden_field :property_id %>
+      <% end %>
+    <ul>
   </div>
   <%= form.hidden_field :name %>
   <%= form.hidden_field :rent %>

--- a/app/views/properties/confirm.html.erb
+++ b/app/views/properties/confirm.html.erb
@@ -9,9 +9,9 @@
     </ul>
   </div>
   <div class="show_station">
-    <% @stations.each do |station| %>
+    <% @stations.each_with_index do |station,index| %>
+      <h2>最寄り駅<%= index + 1 %></h2>
       <ul class="show_list">
-        <h2>最寄り駅</h2>
         <li><span class="show_item">路線名</span> <%= station.line_near %></li>
         <li><span class="show_item">駅名</span> <%= station.station_near %></li>
         <li><span class="show_item">徒歩分数</span> <%= station.minutes_needed %>分</li>

--- a/app/views/properties/confirm.html.erb
+++ b/app/views/properties/confirm.html.erb
@@ -9,26 +9,26 @@
     </ul>
   </div>
   <div class="show_station">
-    <% @stations.each_with_index do |station,index| %>
+          <ul class="show_list">
+    <% @property.stations.each_with_index do |station,index| %>
       <h2>最寄り駅<%= index + 1 %></h2>
-      <ul class="show_list">
         <li><span class="show_item">路線名</span> <%= station.line_near %></li>
         <li><span class="show_item">駅名</span> <%= station.station_near %></li>
         <li><span class="show_item">徒歩分数</span> <%= station.minutes_needed %>分</li>
-      <ul>
-    <% end %>
+        <%= form.fields_for :station do |s| %>
+          <%= s.hidden_field :line_near %>
+          <%= s.hidden_field :station_near %>
+          <%= s.hidden_field :minutes_needed %>
+          <%= s.hidden_field :property_id %>
+        <% end %>
+          <% end %>
+                <ul>
   </div>
   <%= form.hidden_field :name %>
   <%= form.hidden_field :rent %>
   <%= form.hidden_field :place %>
   <%= form.hidden_field :old %>
   <%= form.hidden_field :comment %>
-  <%= form.fields_for :stations do |s| %>
-    <%= s.hidden_field :line_near %>
-    <%= s.hidden_field :station_near %>
-    <%= s.hidden_field :minutes_needed %>
-    <%= s.hidden_field :property_id %>
-  <% end %>
   <p><%= form.submit '登録' %></p>
   <p><%= form.submit '戻る', name:"back" %></p>
 <% end %>

--- a/app/views/properties/confirm.html.erb
+++ b/app/views/properties/confirm.html.erb
@@ -9,13 +9,26 @@
     </ul>
   </div>
   <div class="show_station">
-
+    <% @stations.each do |station| %>
+      <ul class="show_list">
+        <h2>最寄り駅</h2>
+        <li><span class="show_item">路線名</span> <%= station.line_near %></li>
+        <li><span class="show_item">駅名</span> <%= station.station_near %></li>
+        <li><span class="show_item">徒歩分数</span> <%= station.minutes_needed %>分</li>
+      <ul>
+    <% end %>
   </div>
   <%= form.hidden_field :name %>
   <%= form.hidden_field :rent %>
   <%= form.hidden_field :place %>
   <%= form.hidden_field :old %>
   <%= form.hidden_field :comment %>
+  <%= form.fields_for :stations do |s| %>
+    <%= s.hidden_field :line_near %>
+    <%= s.hidden_field :station_near %>
+    <%= s.hidden_field :minutes_needed %>
+    <%= s.hidden_field :property_id %>
+  <% end %>
   <p><%= form.submit '登録' %></p>
   <p><%= form.submit '戻る', name:"back" %></p>
 <% end %>

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -15,6 +15,7 @@
     <li><span class="show_item">駅名</span> <%= station.station_near %></li>
     <li><span class="show_item">徒歩分数</span> <%= station.minutes_needed %>分</li>
   </ul>
+  <% end %>
 </div>
 <p>
   <%= link_to '編集', edit_property_path(@property.id) %> |

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -8,8 +8,8 @@
   </ul>
 </div>
 <div class="show_station">
-  <% @stations.each do |station| %>
-    <h2>最寄り駅</h2>
+  <% @stations.each_with_index do |station,index| %>
+    <h2>最寄り駅<%= index + 1 %></h2>
     <ul class="show_list">
       <li><span class="show_item">路線名</span> <%= station.line_near %></li>
       <li><span class="show_item">駅名</span> <%= station.station_near %></li>

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -8,7 +8,13 @@
   </ul>
 </div>
 <div class="show_station">
-
+  <% @stations.each do |station| %>
+  <ul class="show_list">
+    <h2>最寄り駅</h2>
+    <li><span class="show_item">路線名</span> <%= station.line_near %></li>
+    <li><span class="show_item">駅名</span> <%= station.station_near %></li>
+    <li><span class="show_item">徒歩分数</span> <%= station.minutes_needed %>分</li>
+  </ul>
 </div>
 <p>
   <%= link_to '編集', edit_property_path(@property.id) %> |

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -9,12 +9,12 @@
 </div>
 <div class="show_station">
   <% @stations.each do |station| %>
-  <ul class="show_list">
     <h2>最寄り駅</h2>
-    <li><span class="show_item">路線名</span> <%= station.line_near %></li>
-    <li><span class="show_item">駅名</span> <%= station.station_near %></li>
-    <li><span class="show_item">徒歩分数</span> <%= station.minutes_needed %>分</li>
-  </ul>
+    <ul class="show_list">
+      <li><span class="show_item">路線名</span> <%= station.line_near %></li>
+      <li><span class="show_item">駅名</span> <%= station.station_near %></li>
+      <li><span class="show_item">徒歩分数</span> <%= station.minutes_needed %>分</li>
+    </ul>
   <% end %>
 </div>
 <p>

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -8,13 +8,15 @@
   </ul>
 </div>
 <div class="show_station">
-  <% @stations.each_with_index do |station,index| %>
-    <h2>最寄り駅<%= index + 1 %></h2>
-    <ul class="show_list">
-      <li><span class="show_item">路線名</span> <%= station.line_near %></li>
-      <li><span class="show_item">駅名</span> <%= station.station_near %></li>
-      <li><span class="show_item">徒歩分数</span> <%= station.minutes_needed %>分</li>
-    </ul>
+  <% if !@stations.blank? %>
+    <% @stations.each_with_index do |station,index| %>
+      <h2>最寄り駅<%= index + 1 %></h2>
+      <ul class="show_list">
+        <li><span class="show_item">路線名</span> <%= station.line_near %></li>
+        <li><span class="show_item">駅名</span> <%= station.station_near %></li>
+        <li><span class="show_item">徒歩分数</span> <%= station.minutes_needed %>分</li>
+      </ul>
+    <% end %>
   <% end %>
 </div>
 <p>

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -21,5 +21,5 @@
 </div>
 <p>
   <%= link_to '編集', edit_property_path(@property.id) %> |
-  <%= link_to '戻る', 'javascript:history.back()' %>
+  <%= link_to '戻る', properties_path %>
 </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
+  root to: 'properties#index'
   resources :properties, only: %i(index show new create edit update destroy) do
     collection do
       post 'confirm'
     end
   end
-  root to: 'properties#index'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,9 @@
-10.times do
-  Property.create(name:"物件",rent:100000,place:"住所",old:20,comment:"備考")
+5.times do
+  Property.create(name:"物件",rent:100000,place:"住所",old:20,comment:"備考", stations_attributes:[
+    {
+      line_near:"最寄りの路線",
+      station_near:"最寄り駅",
+      minutes_needed:10
+    }
+    ])
 end


### PR DESCRIPTION
 -最寄り駅を詳細表示画面で表示するよう設定

-最寄り駅を物件と同時に登録・編集出来るよう実装
  -新規登録時は2つ、編集時は今登録されている最寄り駅の数+1つフォームが出る
  -最寄り駅の各カラムはいずれかが空でも可だが、全てが空だとレコードを作成しないようにした

-各ビューの戻るボタンの遷移先を変更(:backから、動線を考えて具体的な戻り先を指定するようにした)

-記述の見直し、調整(%記法の使用、改行の見直し、書き順の見直し等）
